### PR TITLE
feat: binary for send_chunk_header=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ file name must be matched `*_function.xml`).
     <!-- WKT -->
     <function>
         <name>readWktLineString</name>
-        <type>executable</type>
+        <type>executable_pool</type>
         <return_type>Array(Point)</return_type>
         <argument>
             <type>String</type>
@@ -52,7 +52,7 @@ file name must be matched `*_function.xml`).
     <!-- VIN -->
     <function>
         <name>vinCleaner</name>
-        <type>executable</type>
+        <type>executable_pool</type>
         <command>vin-cleaner</command>
         <format>TabSeparated</format>
         <argument>
@@ -63,7 +63,7 @@ file name must be matched `*_function.xml`).
     </function>
     <function>
         <name>vinYear</name>
-        <type>executable</type>
+        <type>executable_pool</type>
         <command>vin-year</command>
         <format>TabSeparated</format>
         <argument>
@@ -74,9 +74,10 @@ file name must be matched `*_function.xml`).
     </function>
     <function>
         <name>vinManuf</name>
-        <type>executable</type>
+        <type>executable_pool</type>
         <format>TabSeparated</format>
-        <command>vin-manuf</command>
+        <command>vin-manuf-chunk-header</command>
+        <send_chunk_header>1</send_chunk_header>
         <argument>
             <type>String</type>
             <name>value</name>
@@ -87,7 +88,7 @@ file name must be matched `*_function.xml`).
     <!-- URL -->
     <function>
         <name>extractUrl</name>
-        <type>executable</type>
+        <type>executable_pool</type>
         <format>TabSeparated</format>
         <command>extract-url</command>
         <argument>
@@ -98,7 +99,7 @@ file name must be matched `*_function.xml`).
     </function>
     <function>
         <name>hasUrl</name>
-        <type>executable</type>
+        <type>executable_pool</type>
         <format>TabSeparated</format>
         <command>has-url</command>
         <argument>

--- a/shared/src/io.rs
+++ b/shared/src/io.rs
@@ -1,4 +1,4 @@
-use std::io::{self, BufRead};
+use std::io::{self, BufRead, Write};
 
 pub fn process_stdin(f: fn(&str) -> Option<String>) {
     let stdin = io::stdin();
@@ -11,5 +11,26 @@ pub fn process_stdin(f: fn(&str) -> Option<String>) {
 
         // Stdout
         println!("{}", output);
+    }
+}
+
+pub fn process_stdin_send_chunk_header(f: fn(&str) -> Option<String>) {
+    let stdin = io::stdin();
+
+    let mut lines = stdin.lock().lines();
+
+    // Read chunk length
+    while let Some(Ok(line)) = lines.next() {
+        let length: usize = line.trim().parse().expect("Failed to parse chunk length");
+
+        for _ in 0..length {
+            if let Some(Ok(line)) = lines.next() {
+                let output = f(&line).unwrap_or_default();
+                println!("{}", output);
+            }
+        }
+
+        // Flush stdout
+        io::stdout().flush().expect("Error flushing stdout");
     }
 }

--- a/vin/Cargo.toml
+++ b/vin/Cargo.toml
@@ -8,12 +8,24 @@ name = "vin-cleaner"
 path = "src/bin/vin-cleaner.rs"
 
 [[bin]]
+name = "vin-cleaner-chunk-header"
+path = "src/bin/vin-cleaner-chunk-header.rs"
+
+[[bin]]
 name = "vin-year"
 path = "src/bin/vin-year.rs"
 
 [[bin]]
+name = "vin-year-chunk-header"
+path = "src/bin/vin-year-chunk-header.rs"
+
+[[bin]]
 name = "vin-manuf"
 path = "src/bin/vin-manuf.rs"
+
+[[bin]]
+name = "vin-manuf-chunk-header"
+path = "src/bin/vin-manuf-chunk-header.rs"
 
 [dependencies]
 anyhow = "1.0.80"

--- a/vin/src/bin/vin-cleaner-chunk-header.rs
+++ b/vin/src/bin/vin-cleaner-chunk-header.rs
@@ -1,0 +1,9 @@
+use anyhow::Result;
+use shared::io::process_stdin_send_chunk_header;
+use vin::vin::vin_cleaner;
+
+fn main() -> Result<()> {
+    process_stdin_send_chunk_header(vin_cleaner);
+
+    Ok(())
+}

--- a/vin/src/bin/vin-manuf-chunk-header.rs
+++ b/vin/src/bin/vin-manuf-chunk-header.rs
@@ -1,0 +1,9 @@
+use anyhow::Result;
+use shared::io::process_stdin_send_chunk_header;
+use vin::vin::vin_manuf;
+
+fn main() -> Result<()> {
+    process_stdin_send_chunk_header(vin_manuf);
+
+    Ok(())
+}

--- a/vin/src/bin/vin-year-chunk-header.rs
+++ b/vin/src/bin/vin-year-chunk-header.rs
@@ -1,0 +1,9 @@
+use anyhow::Result;
+use shared::io::process_stdin;
+use vin::vin::vin_year;
+
+fn main() -> Result<()> {
+    process_stdin(vin_year);
+
+    Ok(())
+}


### PR DESCRIPTION
If you want to use `<send_chunk_header>1</send_chunk_header>` please refer to the binary with `*-chunk-header` suffer.

```xml
<function>
    <name>vinManuf</name>
    <type>executable_pool</type>
    <format>TabSeparated</format>

    <command>vin-manuf-chunk-header</command>
    <send_chunk_header>1</send_chunk_header>

    <argument>
        <type>String</type>
        <name>value</name>
    </argument>
    <return_type>String</return_type>
</function>
```