### PR TITLE
Add extract-phone function to string project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,6 +993,7 @@ name = "string"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "regex",
  "shared",
 ]
 

--- a/README.md
+++ b/README.md
@@ -369,6 +369,12 @@ $ ls -lhp target/release | grep -v '/\|\.d'
 
 
 
+# Generate README
+
+```bash
+RELEASE_VERSION=0.1.8 cargo run --bin readme-generator . > README.md
+```
+
 # License
 
 MIT

--- a/README.tpl
+++ b/README.tpl
@@ -120,6 +120,12 @@ $ ls -lhp target/release | grep -v '/\|\.d'
 
 {% endfor %}
 
+# Generate README
+
+```bash
+RELEASE_VERSION={{ version }} cargo run --bin readme-generator . > README.md
+```
+
 # License
 
 MIT

--- a/string/Cargo.toml
+++ b/string/Cargo.toml
@@ -7,6 +7,11 @@ edition = "2021"
 name = 'string-format'
 path = 'src/bin/string-format.rs'
 
+[[bin]]
+name = 'extract-phone'
+path = 'src/bin/extract-phone.rs'
+
 [dependencies]
 anyhow = "1.0.82"
+regex = "1.10.4"
 shared = { path = "../shared" }

--- a/string/src/bin/extract-phone.rs
+++ b/string/src/bin/extract-phone.rs
@@ -1,23 +1,24 @@
-use shared::io::process_stdin;
 use regex::Regex;
+use shared::io::process_stdin;
 
 fn extract_phone(input: &str) -> Option<String> {
-    let phone_regex = Regex::new(r"\+?\d[\d -]{8,}\d").unwrap();
-    let mut numbers = Vec::new();
+    let phone_regex = Regex::new(r"\+?\d[\d -]{8,}\d").ok()?;
 
-    for cap in phone_regex.captures_iter(input) {
+    if let Some(cap) = phone_regex.captures_iter(input).next() {
         let phone = cap.get(0).map_or("", |m| m.as_str());
-        let normalized_phone = phone.chars().filter(|c| c.is_digit(10)).collect::<String>();
-        numbers.push(normalized_phone);
+        let normalized_phone = phone
+            .chars()
+            .filter(|c| c.is_ascii_digit())
+            .collect::<String>();
+
+        return Some(normalized_phone.to_string());
     }
 
-    numbers.first().map(|number| number.to_string())
+    None
 }
 
 fn main() {
-    process_stdin(Box::new(|input| {
-        extract_phone(input)
-    }));
+    process_stdin(Box::new(extract_phone));
 }
 
 #[cfg(test)]
@@ -26,8 +27,19 @@ mod tests {
 
     #[test]
     fn test_extract_phone() {
-        assert_eq!(extract_phone("Call me at +123 456 7890 or +987 654 3210."), Some("1234567890".to_string()));
-        assert_eq!(extract_phone("My number is 123-456-7890."), Some("1234567890".to_string()));
+        assert_eq!(
+            extract_phone("Call me at +123 456 7890 or +987 654 3210."),
+            Some("1234567890".to_string())
+        );
+        assert_eq!(
+            extract_phone("My number is 1234567890."),
+            Some("1234567890".to_string())
+        );
+        assert_eq!(
+            extract_phone("My number is 123-456-7890."),
+            Some("1234567890".to_string())
+        );
+        assert_eq!(extract_phone("123-456"), None);
         assert_eq!(extract_phone("No phone number here."), None);
     }
 }

--- a/string/src/bin/extract-phone.rs
+++ b/string/src/bin/extract-phone.rs
@@ -1,0 +1,33 @@
+use shared::io::process_stdin;
+use regex::Regex;
+
+fn extract_phone(input: &str) -> Option<String> {
+    let phone_regex = Regex::new(r"\+?\d[\d -]{8,}\d").unwrap();
+    let mut numbers = Vec::new();
+
+    for cap in phone_regex.captures_iter(input) {
+        let phone = cap.get(0).map_or("", |m| m.as_str());
+        let normalized_phone = phone.chars().filter(|c| c.is_digit(10)).collect::<String>();
+        numbers.push(normalized_phone);
+    }
+
+    numbers.first().map(|number| number.to_string())
+}
+
+fn main() {
+    process_stdin(Box::new(|input| {
+        extract_phone(input)
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_phone() {
+        assert_eq!(extract_phone("Call me at +123 456 7890 or +987 654 3210."), Some("1234567890".to_string()));
+        assert_eq!(extract_phone("My number is 123-456-7890."), Some("1234567890".to_string()));
+        assert_eq!(extract_phone("No phone number here."), None);
+    }
+}


### PR DESCRIPTION
Resolved #31

Adds the `extract-phone` function to the `./string` project for extracting and normalizing phone numbers from input strings.

- **Updates `string/Cargo.toml`**: Adds a new binary target for `extract-phone` and includes the `regex` dependency for pattern matching.
- **Implements `extract-phone` in `string/src/bin/extract-phone.rs`**:
  - Utilizes regular expressions to identify and extract phone numbers from the input.
  - Normalizes extracted phone numbers by removing non-numeric characters.
  - Processes input from stdin and outputs the first found phone number, if multiple are found.
  - Includes unit tests to verify functionality, covering cases with single and multiple phone numbers, and inputs without phone numbers.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/duyet/clickhouse-udf-rs/issues/31?shareId=35735e81-d9fc-4765-9743-445dc9be7f72).